### PR TITLE
fix incorrectly formatted key in apiCaller method

### DIFF
--- a/pkg/token/token.go
+++ b/pkg/token/token.go
@@ -416,7 +416,7 @@ func apiCaller(AccessKeyID, AccessKeySecret, SecurityToken, clusterID string) (s
 	queryStr := "SignatureVersion=" + stsSignVersion
 	queryStr += "&Format=" + respBodyFormat
 	queryStr += "&Timestamp=" + url.QueryEscape(time.Now().UTC().Format(timeFormat))
-	queryStr += "&AccessKgo get github.com/prometheus/client_golang/prometheuseyId=" + AccessKeyID
+	queryStr += "&AccessKeyId=" + AccessKeyID
 	queryStr += "&SignatureMethod=HMAC-SHA1"
 	queryStr += "&Version=" + stsAPIVersion
 	queryStr += "&SignatureNonce=" + uuid.NewV4().String()


### PR DESCRIPTION
I got an error when verifying tokens.

Details:
`could not verify token: input token was not properly formatted: non-whitelisted query parameter "AccessKgo get github.com/prometheus/client_golang/prometheuseyId"`